### PR TITLE
- Consolidate nuget packages, fix MinVer CI build issue

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -2,7 +2,7 @@
 
   <Target Name="Versioning" BeforeTargets="MinVer">
     <PropertyGroup Label="Build">
-      <MinVerDefaultPreReleasePhase>preview</MinVerDefaultPreReleasePhase>
+      <MinVerDefaultPreReleaseIdentifiers>preview.0</MinVerDefaultPreReleaseIdentifiers>
       <!-- Tag your repository with the semantic version e.g. '1.0.0' to version all NuGet packages. If you have
            multiple NuGet packages in your solution and want to version them separately, then uncomment this line
            and tag your repository with the name of the package followed by the semantic version e.g.

--- a/Examples/AnthropicNetDemo/AnthropicNetDemo.csproj
+++ b/Examples/AnthropicNetDemo/AnthropicNetDemo.csproj
@@ -12,7 +12,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Update="Microsoft.VisualStudio.Threading.Analyzers" Version="17.5.22" />    
+    <PackageReference Update="Microsoft.VisualStudio.Threading.Analyzers" Version="17.5.22" />
+    <PackageReference Update="MinVer" Version="4.3.0" />    
   </ItemGroup>
 
 </Project>

--- a/Tests/Anthropic.Net.Tests/Anthropic.Net.Test.csproj
+++ b/Tests/Anthropic.Net.Tests/Anthropic.Net.Test.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup Label="Build">
     <TargetFramework>net6.0</TargetFramework>
@@ -6,6 +6,10 @@
 
   <ItemGroup Label="Project References">
     <ProjectReference Include="..\..\Source\Anthropic.Net\Anthropic.Net.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Update="MinVer" Version="4.3.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
- Fix build target entry for MinVer leading to CI build action error: "MinVer : warning MINVER1008: MinVerDefaultPreReleasePhase is deprecated and will be removed in the next major version."

<!--
Thank you good citizen for your hard work!

Please read the contributing guide before raising a pull request.
https://github.com/tinonetic/anthropic.net/blob/main/.github/CONTRIBUTING.md
-->
